### PR TITLE
Fix compilation issues on scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ libraryDependencies ++= Seq(
   "io.kamon" %% "kamon-core" % "2.0.1",
   "com.newrelic.telemetry" % "telemetry" % "0.3.2",
   "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.3.2",
-  scalatest % "test",
-  "org.mockito" % "mockito-core" % "3.1.0" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "org.mockito" % "mockito-core" % "3.1.0" % "test",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.3"
 )

--- a/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
+++ b/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
@@ -35,7 +35,7 @@ object NewRelicDistributionMetrics {
 
       val summary: Summary = buildSummary(start, end, dist, instrumentBaseAttributes, distValue)
       val percentiles: scala.Seq[_root_.com.newrelic.telemetry.metrics.Metric] = makePercentiles(dist.name, end, distValue, instrumentBaseAttributes)
-      percentiles.appended(summary)
+      percentiles :+ summary
     }
   }
 


### PR DESCRIPTION
There are some mismatch in collection api between 2.12 <-> 2.13 which needed `scala-collection-compat` to be present. Additionally by default scalatest 3.0.5 was selected which is not released for 2.13.